### PR TITLE
Change rgl.lines to segments3d

### DIFF
--- a/R/plot_sg.R
+++ b/R/plot_sg.R
@@ -69,7 +69,7 @@ plot.sg <- function(x, data, which=NULL, add=FALSE,
 #' @param x sg object
 #' @param data coordinates
 #' @param which points of which out-edges will be plotted
-#' @param ... passed to rgl.lines
+#' @param ... passed to segments3d
 #'
 #' @export
 plot3_sg <- function(x, data, which, ...) {
@@ -77,7 +77,7 @@ plot3_sg <- function(x, data, which, ...) {
     stop("Package 'rgl' needed for 3D plots of sg-objects.")
   }
   else{
-    liner <- rgl::rgl.lines
+    liner <- rgl::segments3d
   }
   A <- sg2adj(x)$matrix
 

--- a/man/plot3_sg.Rd
+++ b/man/plot3_sg.Rd
@@ -13,7 +13,7 @@ plot3_sg(x, data, which, ...)
 
 \item{which}{points of which out-edges will be plotted}
 
-\item{...}{passed to rgl.lines}
+\item{...}{passed to segments3d}
 }
 \description{
 Plot 3d graph


### PR DESCRIPTION
Some upcoming changes to the rgl package will require changes to
spatgraphs.  I will be deprecating a number of rgl.* function calls.
You can read about the issues here:

        https://dmurdoch.github.io/rgl/articles/deprecation.html

I have made the required changes to spatgraphs in the attached patch
file. These changes should work with both old and new rgl versions.